### PR TITLE
add function src_prep_fini_hook, for post-prep processing

### DIFF
--- a/lib/src_prep.cygpart
+++ b/lib/src_prep.cygpart
@@ -436,6 +436,12 @@ __src_prep() {
 	then
 		cygpatch ${top}/${src_patchfile};
 	fi
+
+	if __check_function src_prep_fini_hook
+	then
+		__check_unstable src_prep_fini_hook;
+		cd ${origsrcdir}/${SRC_DIR};
+	fi
 }
 
 readonly -f __cpio_gz_extract __gem_extract __srpm_extract unpack \


### PR DESCRIPTION
Run function `src_prep_fini_hook` if present after prep is complete, to perform post-prep processing. AFAICT this is the only way to copy new files into the source directory before building, without keeping those files as patches (which are inconvenient). For example in my .cygport.conf I have
```
CYGPORT_USE_UNSTABLE_API=1
src_prep_fini_hook ()
{
  cd "${top}"
  # copy in extra files
  if [[ -d extras && "$(ls extras)" ]] ; then
    inform "Copying in extra files"
    cp -a extras/* "${S}"
  fi
}
```
See the [previous discussion on cygwin-apps](https://sourceware.org/ml/cygwin-apps/2014-10/msg00048.html). There you suggested that if all that's needed is to copy in source files, one could achieve that by adding them to the SRC_URI. But I've tried that, for example
```
SRC_URI="
  https://github.com/fish-shell/fish-shell/releases/download/$VERSION/fish-$VERSION.tar.gz
  extras/*
"
```
and the result is always errors like
```
ASchulma@LZ77E1AASCHULMA ~/d/c/fish> cygport fish.cygport finish prep
>>> Removing work directory in 5 seconds...
>>> Removing work directory NOW.
>>> Finished.
>>> Preparing fish-2.6b1-1.x86_64
>>> Unpacking source fish-2.6b1.tar.gz
*** ERROR: Cannot find source package etc
```
where extras/etc is one of the directories I want to copy into the source code. By contrast, this patch is simple, works fine, and seems to fill a need.

Thanks for your consideration.

