### PR TITLE
Bugfix: Freeze just after displaying `Fixing libtool modules:`.

### DIFF
--- a/lib/src_postinst.cygpart
+++ b/lib/src_postinst.cygpart
@@ -1294,7 +1294,7 @@ __prep_libtool_modules() {
 				else
 					origdlname=${dlname}
 
-					while [ $(readlink -f ${ltlibdir}/${dlname%/bin/*}) != ${D}$(__host_prefix) ]
+					while [ $(readlink -f ${ltlibdir}/${dlname%/bin/*}) != $(readlink -f ${D}$(__host_prefix) ) ]
 					do
 						dlname=../${dlname}
 					done


### PR DESCRIPTION
If working directory containing symbolic links,
`cygport` will freeze just after displaying `Fixing libtool modules:`.